### PR TITLE
Add missing Microformats and more

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -6,3 +6,7 @@
 <script src="{{ "assets/js/main.js" | relURL }}"></script>
 <script src="{{ "assets/js/highlight.js" | relURL }}"></script>
 <script>hljs.initHighlightingOnLoad();</script>
+
+{{ range .Site.Params.plugins_js }}
+    <script src="{{ . }}"></script>
+{{ end }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -37,4 +37,7 @@
 	<link rel="microsub" href="https://micro.blog/microsub" />
 	<link rel="webmention" href="https://micro.blog/webmention" />
 	<link rel="subscribe" href="https://micro.blog/users/follow" />
+	{{ range .Site.Params.plugins_css }}
+		<link rel="stylesheet" href="{{ . }}" />
+	{{ end }}
 </head>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -40,4 +40,7 @@
 	{{ range .Site.Params.plugins_css }}
 		<link rel="stylesheet" href="{{ . }}" />
 	{{ end }}
+	{{ range $filename := .Site.Params.plugins_html }}
+		{{ partial $filename $ }}
+	{{ end }}
 </head>

--- a/layouts/partials/post-list.html
+++ b/layouts/partials/post-list.html
@@ -1,4 +1,4 @@
-<ul id="post-list">
+<ul id="post-list" class="h-feed">
 
 {{ $paginator := .Paginate (where .Site.Pages.ByDate.Reverse "Type" "post") (index .Site.Params "archive-paginate" | default 25) }}
 {{ range $paginator.Pages  }}
@@ -6,7 +6,7 @@
         <li class="h-entry">
             <a href="{{ .Permalink }}" class="u-url"><aside class="dates"><time datetime="{{ .Date.Format "2006-01-02 15:04:05 -0700" }}" class="dt-published">{{ .Date.Format "3:04 PM, Jan 2" }}</time></aside></a>
 			{{ if .Title }}
-				<h1><a href="{{ .Permalink }}">{{ .Title }}</a></h1>
+				<h1><a href="{{ .Permalink }}" class="p-name">{{ .Title }}</a></h1>
 			{{ end }}
             <a href="{{ .Permalink }}"><h2 class="e-content">{{ .Content }}</h2></a>
         </li>

--- a/layouts/partials/post-list.html
+++ b/layouts/partials/post-list.html
@@ -1,6 +1,6 @@
 <ul id="post-list">
 
-{{ $paginator := .Paginate (where .Data.Pages.ByDate.Reverse "Type" "post") (index .Site.Params "archive-paginate" | default 25) }}
+{{ $paginator := .Paginate (where .Site.Pages.ByDate.Reverse "Type" "post") (index .Site.Params "archive-paginate" | default 25) }}
 {{ range $paginator.Pages  }}
 
         <li class="h-entry">

--- a/layouts/partials/post-list.html
+++ b/layouts/partials/post-list.html
@@ -1,6 +1,7 @@
 <ul id="post-list" class="h-feed">
 
-{{ $paginator := .Paginate (where .Site.Pages.ByDate.Reverse "Type" "post") (index .Site.Params "archive-paginate" | default 25) }}
+{{ $pages := cond .IsHome .Site.Pages .Pages }}
+{{ $paginator := .Paginate (where $pages.ByDate.Reverse "Type" "post") (index .Site.Params "archive-paginate" | default 25) }}
 {{ range $paginator.Pages  }}
 
         <li class="h-entry">

--- a/layouts/post/single.html
+++ b/layouts/post/single.html
@@ -6,7 +6,7 @@
 		{{ end }}
         <h2 class="headline"><a href="{{ .Permalink }}" class="u-url"><time class="dt-published" datetime="{{ .Date.Format "2006-01-02 15:04:05 -0700" }}">{{ .Date.Format "Jan 2, 2006" }}</time></a></h2>
     </header>
-    <section id="post-body e-content">
+    <section id="post-body" class="e-content">
         {{ .Content }}
     </section>
 </article>

--- a/layouts/post/single.html
+++ b/layouts/post/single.html
@@ -2,7 +2,7 @@
 <article class="post h-entry">
     <header>
 		{{ if .Title }}
-			<h1>{{ .Title }}</h1>
+			<h1 class="p-name">{{ .Title }}</h1>
 		{{ end }}
         <h2 class="headline"><time class="dt-published" datetime="{{ .Date.Format "2006-01-02 15:04:05 -0700" }}">{{ .Date.Format "Jan 2, 2006" }}</time></h2>
     </header>

--- a/layouts/post/single.html
+++ b/layouts/post/single.html
@@ -4,7 +4,7 @@
 		{{ if .Title }}
 			<h1 class="p-name">{{ .Title }}</h1>
 		{{ end }}
-        <h2 class="headline"><time class="dt-published" datetime="{{ .Date.Format "2006-01-02 15:04:05 -0700" }}">{{ .Date.Format "Jan 2, 2006" }}</time></h2>
+        <h2 class="headline"><a href="{{ .Permalink }}" class="u-url"><time class="dt-published" datetime="{{ .Date.Format "2006-01-02 15:04:05 -0700" }}">{{ .Date.Format "Jan 2, 2006" }}</time></a></h2>
     </header>
     <section id="post-body e-content">
         {{ .Content }}

--- a/plugin.json
+++ b/plugin.json
@@ -1,5 +1,5 @@
 {
-	"version": "1.0",
+	"version": "1.0.1",
 	"title": "Cactus theme",
 	"description": "Changes your blog to use the Cactus theme."
 }

--- a/static/assets/css/style.css
+++ b/static/assets/css/style.css
@@ -186,7 +186,7 @@ ul 	{ margin:0; padding:0; }
 li	{ list-style-type:circle; list-style-position:inside; }
 
 /* Line Height */
-#post-body, p { line-height:1.7; font-size: 120%; }
+p { line-height:1.7; font-size: 120%; }
 
 b, strong { font-weight: 500;
   color: #1E2025; }

--- a/static/assets/css/style.css
+++ b/static/assets/css/style.css
@@ -251,6 +251,10 @@ em, i { font-style: italic; }
 	  display: inline-block;
 }
 
+.post h2.headline a {
+	color: #b2b9be;
+}
+
 #post-list h2 {
 	font: normal 17px/1.5em "Helvetica Neue",Helvetica,Arial,sans-serif;
 	color: #aaa;


### PR DESCRIPTION
This pull request adds

- Missing Microformats
- Support for JavaScript, HTML, and CSS from plug-ins

Also, a couple of styling tweaks to keep the old look after structural HTML changes. And a version bump. And…

## Re-add post listing on the homepage for Hugo 0.91

This pull request also fixes the missing post listing on the homepage. This was tracked down to the usage of `Data.Pages` instead of `Site.Pages`.